### PR TITLE
Update client interface to not require kwargs for non-env construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Before using EasyGmail, ensure you have an [app password](https://support.google
 ```python
 from easygmail import Client, EmailBuilder
 
-client = Client(email_address="<address>@gmail.com", password="<app password>")
+client = Client("<address>@gmail.com", "<app password>")
 
 msg = EmailBuilder(
     receiver="<recipient>@domain.com", subject="<subject text>", body="<body text>"
@@ -40,7 +40,7 @@ You can instantiate a `Client` object in two ways:
 ```python
 from easygmail import Client
 
-client = Client(email_address="<address>@gmail.com", password="<app password>")
+client = Client("<address>@gmail.com", "<app password>")
 ```
 
 2. **Environment File**:

--- a/easygmail/client.py
+++ b/easygmail/client.py
@@ -3,6 +3,7 @@ import smtplib
 from email.message import EmailMessage
 
 from dotenv import load_dotenv
+
 from .validation import validate_gmail, validate_password
 
 
@@ -30,7 +31,7 @@ class Client:
     """
 
     def __init__(
-        self, env_file: str = None, email_address: str = None, password: str = None
+        self, email_address: str = None, password: str = None, env_file: str = None
     ) -> None:
         if env_file:
             load_dotenv(env_file)


### PR DESCRIPTION
 Modified `Client` to not require kwargs for non-env client construction. New instantiations look like: `Client(email, password)`. Also sorted imports using `isort`.